### PR TITLE
Better command line arguments

### DIFF
--- a/AmbientReminders/README.md
+++ b/AmbientReminders/README.md
@@ -69,9 +69,17 @@ Creating ambient reminders for upcoming appointments.
   and to start the local-server do the following and go to `http://localhost:5000/` in your browser:
   ```node app.js```
 
+<br/>
 
-
-
+####Command line arguments:
+1. Type: 
+     * `--solid`  or `-s`
+     * `--linear` or `-l`
+     * `--exponential` or `-e`
+2. Length:
+     * `--length 10` (in minutes)
+3. Lightness (optional): 
+     * `--lightness 0.7`
 
 
 <br/>

--- a/AmbientReminders/src/blink.js
+++ b/AmbientReminders/src/blink.js
@@ -3,6 +3,7 @@ var color = require('onecolor');
 var moment = require('moment');
 var schedule = require('node-schedule');
 var later = require("later");
+var commandLineArgs = require('command-line-args');
 
 /**
  * onecolor usage example:
@@ -97,24 +98,36 @@ process.on('uncaughtException', exitHandler.bind(null, {
     exit: true
 }));
 
-var args = process.argv.slice(2);
-var type = args[0];
-var length = args[1];
+
+const cli = commandLineArgs([{
+    name: 'solid',
+    alias: 's',
+    type: Boolean
+}, {
+    name: 'linear',
+    alias: 'l',
+    type: Boolean
+}, {
+    name: 'exponential',
+    alias: 'e',
+    type: Boolean
+}, {
+    name: 'length',
+    type: Number
+}, {
+    name: 'lightness',
+    type: Number
+}]);
+const options = cli.parse();
+
 var lightness;
-if (typeof args[2] !== 'undefined')
-    lightness = args[2];
-else
-    lightness = 1;
-
-
-if (type === "linear") {
-    linear(length, pulseAlarm, 60, lightness);
-} else if (type === "exponential") {
-    exponential(length);
-} else if (type === "solid") {
-    linear(length, solidAlarm, 1, lightness);
-}
-
+options.lightness != undefined ? lightness = options.lightness : lightness = 1;
+if(options.solid)
+    linear(options.length, solidAlarm, 1, lightness);
+else if(options.linear)
+    linear(options.length, pulseAlarm, 60, lightness);
+else if(options.exponential)
+    exponential(options.length);
 
 
 //******************************** PATTERS **********************************↓
@@ -381,5 +394,3 @@ function pomodoroT(lightness) {
     }, sched);
     
 }
-
-pomodoroT(1);

--- a/AmbientReminders/src/package.json
+++ b/AmbientReminders/src/package.json
@@ -20,7 +20,8 @@
     "promise": "^7.0.4",
     "underscore": "^1.8.3",
     "node-schedule": "^0.2.9",
-    "later": "^1.2.0"
+    "later": "^1.2.0",
+    "command-line-args": "2.1.6"
   },
   "engines" : { "node" : ">=0.11.6" }
 }


### PR DESCRIPTION
I kept forgetting the command line arguments order when I didn't use blink for awhile so I thought this might help...

1. Type: 
     * `--solid`  or `-s`
     * `--linear` or `-l`
     * `--exponential` or `-e`
2. Length:
     * `--length 10` (in minutes)
3. Lightness (optional): 
     * `--lightness 0.7`

``` bash
>> node --solid --length 10 --lightness 0.8
```